### PR TITLE
feat: use WA_VERSION in mobile noise connection

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -20,12 +20,13 @@ export const PHONE_CONNECTION_CB = 'CB:Pong'
 
 export const WA_DEFAULT_EPHEMERAL = 7 * 24 * 60 * 60
 
-const WA_VERSION = '2.23.14.82'
+export const WA_VERSION = [2, 23, 14, 82]
+export const WA_VERSION_STRING = WA_VERSION.join('.')
 
-const WA_VERSION_HASH = crypto.createHash('md5').update(WA_VERSION).digest('hex')
+const WA_VERSION_HASH = crypto.createHash('md5').update(WA_VERSION_STRING).digest('hex')
 export const MOBILE_TOKEN = Buffer.from('0a1mLfGUIBVrMKF1RdvLI5lkRBvof6vn0fD2QRSM' + WA_VERSION_HASH)
 export const MOBILE_REGISTRATION_ENDPOINT = 'https://v.whatsapp.net/v2'
-export const MOBILE_USERAGENT = `WhatsApp/${WA_VERSION} iOS/15.3.1 Device/Apple-iPhone_7`
+export const MOBILE_USERAGENT = `WhatsApp/${WA_VERSION_STRING} iOS/15.3.1 Device/Apple-iPhone_7`
 export const REGISTRATION_PUBLIC_KEY = Buffer.from([
 	5, 142, 140, 15, 116, 195, 235, 197, 215, 166, 134, 92, 108, 60, 132, 56, 86, 176, 97, 33, 204, 232, 234, 119, 77,
 	34, 251, 111, 18, 37, 18, 48, 45,

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -1,7 +1,7 @@
 import { Boom } from '@hapi/boom'
 import { createHash } from 'crypto'
 import { proto } from '../../WAProto'
-import { KEY_BUNDLE_TYPE } from '../Defaults'
+import { KEY_BUNDLE_TYPE, WA_VERSION } from '../Defaults'
 import type { AuthenticationCreds, SignalCreds, SocketConfig } from '../Types'
 import { BinaryNode, getBinaryNodeChild, jidDecode, S_WHATSAPP_NET } from '../WABinary'
 import { Curve, hmacSign } from './crypto'
@@ -10,7 +10,7 @@ import { createSignalIdentity } from './signal'
 
 const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 	const osVersion = config.mobile ? '15.3.1' : '0.1'
-	const version = config.mobile ? [2, 22, 24] : config.version
+	const version = config.mobile ? WA_VERSION : config.version
 	const device = config.mobile ? 'iPhone_7' : 'Desktop'
 	const manufacturer = config.mobile ? 'Apple' : ''
 	const platform = config.mobile ? proto.ClientPayload.UserAgent.Platform.IOS : proto.ClientPayload.UserAgent.Platform.MACOS


### PR DESCRIPTION
Currently validate-connection.ts uses a hardcoded version for the mobile api, which results in `405` error when connecting, because the version is too old.
To use the same updated version as registration user_agent, validate-connection.ts now also uses the WA_VERSION constant.